### PR TITLE
feat: implement blog with content collections

### DIFF
--- a/.wrangler/deploy/config.json
+++ b/.wrangler/deploy/config.json
@@ -1,0 +1,1 @@
+{"configPath":"../../dist/server/wrangler.json","auxiliaryWorkers":[],"prerenderWorkerConfigPath":"../../dist/server/.prerender/wrangler.json"}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,6 @@ import cloudflare from '@astrojs/cloudflare';
 
 // https://astro.build/config
 export default defineConfig({
-  adapter: cloudflare()
+  adapter: cloudflare(),
+  output: 'static',
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/cloudflare": "^13.1.0",
+        "@astrojs/rss": "^4.0.17",
         "astro": "^6.0.3",
         "wrangler": "^4.72.0"
       },
@@ -87,6 +88,17 @@
       },
       "engines": {
         "node": "^20.19.1 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.17.tgz",
+      "integrity": "sha512-eV+wdMbeVKC9+sPaV0LN8JL1LGo9YAh3GKl4Ou4nzMNLmXM/aswYpSGxVEAuHilgBZ6/++/Pv08ICmuOqX107w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "5.4.1",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2519,6 +2531,40 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
+      "integrity": "sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3966,6 +4012,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -4473,6 +4534,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "10.2.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.1.0",
+    "@astrojs/rss": "^4.0.17",
     "astro": "^6.0.3",
     "wrangler": "^4.72.0"
   }

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,31 @@
+---
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+const { title, description, pubDate, tags } = post.data;
+
+const formattedDate = pubDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+---
+
+<article>
+  <h2>
+    <a href={`/blog/${post.id}`}>{title}</a>
+  </h2>
+  <time datetime={pubDate.toISOString()}>{formattedDate}</time>
+  {description && <p>{description}</p>}
+  {tags.length > 0 && (
+    <p>
+      {tags.map(tag => (
+        <a href={`/blog/tag/${tag}`}>#{tag}</a>
+      ))}
+    </p>
+  )}
+</article>

--- a/src/components/TagList.astro
+++ b/src/components/TagList.astro
@@ -1,0 +1,27 @@
+---
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog', ({ data }) => !data.draft);
+
+const tagCounts = new Map<string, number>();
+for (const post of posts) {
+  for (const tag of post.data.tags) {
+    tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+  }
+}
+
+const tags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
+---
+
+{tags.length > 0 && (
+  <div>
+    <h3>Tags</h3>
+    <ul>
+      {tags.map(([tag, count]) => (
+        <li>
+          <a href={`/blog/tag/${tag}`}>{tag} ({count})</a>
+        </li>
+      ))}
+    </ul>
+  </div>
+)}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,18 @@
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string().max(100),
+    description: z.string().max(200).optional(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    draft: z.boolean().default(false),
+    tags: z.array(z.string()).default([]),
+    author: z.string().default('Site Author'),
+    image: z.string().optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/content/blog/2026/building-with-astro.md
+++ b/src/content/blog/2026/building-with-astro.md
@@ -1,0 +1,46 @@
+---
+title: "Building with Astro"
+description: "Why we chose Astro for this site"
+pubDate: 2026-03-10
+draft: false
+tags: ["astro", "web-dev", "meta"]
+author: "Jane Doe"
+---
+
+We chose Astro for this site because of its excellent static site generation capabilities and minimal JavaScript approach.
+
+## Why Astro?
+
+### Performance First
+
+Astro ships zero JavaScript by default. Pages are pure HTML and CSS, which means:
+
+- **Fast loading** — no JS blocking the render
+- **Great Lighthouse scores** — out of the box
+- **Low bandwidth** — smaller page sizes
+
+### Content Collections
+
+The built-in Content Collections feature makes managing blog posts a breeze:
+
+```typescript
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog');
+```
+
+### Hosting on Cloudflare
+
+Astro works great with Cloudflare Pages. The adapter is simple:
+
+```javascript
+import cloudflare from '@astrojs/cloudflare';
+
+export default defineConfig({
+  adapter: cloudflare()
+});
+```
+
+## What's Next?
+
+We'll be adding more features soon. Stay tuned!

--- a/src/content/blog/2026/hello-world.md
+++ b/src/content/blog/2026/hello-world.md
@@ -1,0 +1,41 @@
+---
+title: "Hello World"
+description: "The first post on our new blog"
+pubDate: 2026-03-11
+draft: false
+tags: ["announcement", "meta"]
+author: "Jane Doe"
+---
+
+Welcome to our new blog! This is the first post using Astro Content Collections with Markdown.
+
+## What is Content Collections?
+
+Content Collections is Astro's built-in way to manage content. It gives you:
+
+- **Type-safe frontmatter** with Zod validation
+- **Git-tracked content** — version control for your posts
+- **Fast builds** — content is processed at build time
+- **Markdown support** — write in the familiar format
+
+## Writing Posts
+
+You can write posts in any of these ways:
+
+1. **Locally** with your favorite editor (VS Code, Neovim, etc.)
+2. **On GitHub** using the web interface — just create a new `.md` file
+3. **GitHub Codespaces** for a full editing environment in the browser
+
+## Code Example
+
+Here's some JavaScript:
+
+```javascript
+function greet(name) {
+  return `Hello, ${name}!`;
+}
+
+console.log(greet('World'));
+```
+
+That's all for now. More posts coming soon!

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,23 +1,13 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link rel="icon" href="/favicon.ico" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
-	</head>
-	<body>
-		<slot />
-	</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>{Astro.props.title}</title>
+    {Astro.props.description && <meta name="description" content={Astro.props.description} />}
+  </head>
+  <body>
+    <slot />
+  </body>
 </html>
-
-<style>
-	html,
-	body {
-		margin: 0;
-		width: 100%;
-		height: 100%;
-	}
-</style>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,0 +1,47 @@
+---
+import Layout from './Layout.astro';
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+const { title, description, pubDate, updatedDate, author, tags } = post.data;
+
+const formattedDate = pubDate.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const formattedUpdated = updatedDate?.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+---
+
+<Layout title={title} description={description}>
+  <article>
+    <header>
+      <h1>{title}</h1>
+      <p>
+        <time datetime={pubDate.toISOString()}>{formattedDate}</time>
+        {formattedUpdated && <span>(updated {formattedUpdated})</span>}
+        <span>by {author}</span>
+      </p>
+      {tags.length > 0 && (
+        <p>
+          {tags.map(tag => (
+            <a href={`/blog/tag/${tag}`}>#{tag}</a>
+          ))}
+        </p>
+      )}
+    </header>
+    
+    <div>
+      <slot />
+    </div>
+  </article>
+</Layout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,22 @@
+---
+import { getCollection, render } from 'astro:content';
+import PostLayout from '../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  
+  return posts
+    .filter(post => !post.data.draft)
+    .map(post => ({
+      params: { slug: post.id },
+      props: { post },
+    }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+---
+
+<PostLayout post={post}>
+  <Content />
+</PostLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,22 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../layouts/Layout.astro';
+import PostCard from '../../components/PostCard.astro';
+import TagList from '../../components/TagList.astro';
+
+const posts = await getCollection('blog', ({ data }) => !data.draft);
+const sortedPosts = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Layout title="Blog" description="All blog posts">
+  <h1>Blog</h1>
+  <p><a href="/rss.xml">RSS Feed</a></p>
+  
+  {sortedPosts.length === 0 ? (
+    <p>No posts yet.</p>
+  ) : (
+    sortedPosts.map(post => <PostCard post={post} />)
+  )}
+  
+  <TagList />
+</Layout>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,0 +1,34 @@
+---
+import { getCollection } from 'astro:content';
+import Layout from '../../../layouts/Layout.astro';
+import PostCard from '../../../components/PostCard.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  
+  const tags = new Set<string>();
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      tags.add(tag);
+    }
+  }
+  
+  return Array.from(tags).map(tag => ({
+    params: { tag },
+    props: { 
+      tag,
+      posts: posts.filter(post => post.data.tags.includes(tag))
+        .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+    },
+  }));
+}
+
+const { tag, posts } = Astro.props;
+---
+
+<Layout title={`Posts tagged #${tag}`} description={`All posts tagged with ${tag}`}>
+  <h1>Posts tagged #{tag}</h1>
+  <p><a href="/blog">← All posts</a></p>
+  
+  {posts.map(post => <PostCard post={post} />)}
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,23 @@
 ---
-import Welcome from '../components/Welcome.astro';
+import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
+import PostCard from '../components/PostCard.astro';
 
-// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
-// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+const posts = await getCollection('blog', ({ data }) => !data.draft);
+const recentPosts = posts
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 5);
 ---
 
-<Layout>
-	<Welcome />
+<Layout title="Home" description="Welcome to my site">
+  <h1>Welcome</h1>
+  <p>This is my site built with Astro and hosted on Cloudflare.</p>
+  <p><a href="/blog">Read the Blog</a></p>
+  
+  <h2>Recent Posts</h2>
+  {recentPosts.length === 0 ? (
+    <p>No posts yet.</p>
+  ) : (
+    recentPosts.map(post => <PostCard post={post} />)
+  )}
 </Layout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection('blog', ({ data }) => !data.draft);
+  
+  const sortedPosts = posts.sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+  );
+
+  return rss({
+    title: 'My Blog',
+    description: 'Thoughts, tutorials, and updates.',
+    site: context.site?.toString() || 'https://example.com',
+    items: sortedPosts.map(post => ({
+      title: post.data.title,
+      pubDate: post.data.pubDate,
+      description: post.data.description,
+      link: `/blog/${post.id}/`,
+      author: post.data.author,
+    })),
+    customData: `<language>en-us</language>`,
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements a blog using Astro's Content Collections with Markdown.

## Features

- **Content Collections** with Zod schema validation for type-safe frontmatter
- **Blog index page** (`/blog`) with tag sidebar
- **Individual post pages** with `[...slug]` routing for nested paths (e.g., `/blog/2026/hello-world`)
- **Tag filter pages** (`/blog/tag/[tag]`)
- **RSS feed** via `@astrojs/rss`
- **Homepage** shows 5 most recent posts
- **Draft support** - posts marked `draft: true` are excluded from production builds

## Content Schema

| Field | Type | Description |
|-------|------|-------------|
| title | string (max 100) | Post title |
| description | string (max 200, optional) | Short excerpt |
| pubDate | Date | Publication date |
| updatedDate | Date (optional) | Last updated |
| draft | boolean (default: false) | Draft status |
| tags | string[] (default: []) | Post tags |
| author | string (default: 'Site Author') | Author name |
| image | string (optional) | Hero image path |

## Writing Posts

Authors can write posts in three ways:

1. **Locally** with any text editor (VS Code, Neovim, Obsidian, etc.)
2. **GitHub web UI** - go to `src/content/blog/`, click "Add file" → "Create new file"
3. **GitHub Codespaces** for a full editing environment

Posts are stored as Markdown files in `src/content/blog/[year]/`.

## Sample Posts

Added two sample posts:
- `hello-world.md` - Introduction to Content Collections
- `building-with-astro.md` - Why we chose Astro

## Dependencies Added

- `@astrojs/rss` - RSS feed generation
