### PR TITLE
Remove Budget and Organizational Plan documents

### DIFF
--- a/src/components/pages/DocumentsPage.astro
+++ b/src/components/pages/DocumentsPage.astro
@@ -26,23 +26,7 @@ const documents: Document[] = [
     file: t(locale, 'documents.list.0.file'),
     date: new Date('2025-08-31'),
   },
-  {
-    name: t(locale, 'documents.list.1.name'),
-    description: t(locale, 'documents.list.1.description'),
-    file: t(locale, 'documents.list.1.file'),
-    date: new Date('2025-12-12'),
-  },
-  {
-    name: t(locale, 'documents.list.2.name'),
-    description: t(locale, 'documents.list.2.description'),
-    file: t(locale, 'documents.list.2.file'),
-    date: new Date('2025-12-12'),
-  },
-].sort((a, b) => {
-  const dateCompare = b.date.getTime() - a.date.getTime();
-  if (dateCompare !== 0) return dateCompare;
-  return a.name.localeCompare(b.name);
-});
+];
 ---
 
 <Layout

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -76,16 +76,6 @@
         "name": "Basis of Unity",
         "description": "The founding document of OTD / OP, debated, amended and voted upon at the Off the Defensive Conference. It establishes the objective situation, our strategic horizon of socialism, and the organizational structure of chapters and coordinating committees.",
         "file": "/documents/basis_of_unity.pdf"
-      },
-      {
-        "name": "Budget and Fundraising Proposal",
-        "description": "The 2026 budget proposal including projected costs for the Founding Assembly and a chapter-based fundraising strategy where each chapter raises funds per member to centralize resources.",
-        "file": "/documents/budget_and_fundraising_plan.pdf"
-      },
-      {
-        "name": "Organizational Plan",
-        "description": "Details the organization's central plans from 2025-2026 leading up to the Founding Assembly, including quarterly milestones for chapter launches, political education, and expansion into new cities.",
-        "file": "/documents/organizational_plan.pdf"
       }
     ]
   },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -76,16 +76,6 @@
         "name": "Base d'Unité",
         "description": "Le document fondateur d'OTD / OP, débattu, amendé et voté lors de la Conférence Off the Defensive. Il établit la situation objective, notre horizon stratégique du socialisme, et la structure organisationnelle des chapitres et des comités de coordination.",
         "file": "/documents/base_dunite.pdf"
-      },
-      {
-        "name": "Proposition de Budget et de Financement",
-        "description": "La proposition budgétaire pour 2026 incluant les coûts prévus pour l'Assemblée Fondatrice et une stratégie de financement basée sur les chapitres où chaque chapitre collecte des fonds par membre pour centraliser les ressources.",
-        "file": "/documents/budget_et_plan_de_financement.pdf"
-      },
-      {
-        "name": "Plan Organisationnel",
-        "description": "Détaille les plans centraux de l'organisation de 2025-2026 menant à l'Assemblée Fondatrice, incluant les jalons trimestriels pour le lancement des chapitres, l'éducation politique et l'expansion vers de nouvelles villes.",
-        "file": "/documents/plan_organisationnel.pdf"
       }
     ]
   },


### PR DESCRIPTION
## Summary
This PR removes the Budget and Fundraising Proposal and Organizational Plan documents from the website, keeping only the Basis of Unity.

## Changes
- Remove Budget and Fundraising Proposal (English and French versions)
- Remove Organizational Plan (English and French versions)
- Update DocumentsPage to only show Basis of Unity
- Delete associated PDF files from public/documents/:
  - budget_and_fundraising_plan.pdf
  - budget_et_plan_de_financement.pdf
  - organizational_plan.pdf
  - plan_organisationnel.pdf
- PDFs have been completely removed from git history (force pushed)

## Remaining Documents
- Basis of Unity (August 31, 2025)
- Base d'Unité (August 31, 2025)

All checks pass.